### PR TITLE
Feat/test data

### DIFF
--- a/.github/workflows/data-pipeline.yaml
+++ b/.github/workflows/data-pipeline.yaml
@@ -118,7 +118,7 @@ jobs:
       - name: Validate landings
         run: Rscript -e 'peskas.timor.data.pipeline::validate_landings()'
       - name: Test validated landings
-        run: Rscript -e 'tinytest::run_test_file("inst/tinytest/test_validated_landings.R")'
+        run: Rscript -e 'tinytest::run_test_file(system.file("tinytest/test_validated_landings.R", package = "peskas.timor.data.pipeline"))'
 
   ingest-pds-trips:
     name: Ingest pds trips

--- a/.github/workflows/data-pipeline.yaml
+++ b/.github/workflows/data-pipeline.yaml
@@ -139,6 +139,8 @@ jobs:
         run: Rscript -e 'peskas.timor.data.pipeline::preprocess_pds_trips()'
       - name: Call validate_pds_trips()
         run: Rscript -e 'peskas.timor.data.pipeline::validate_pds_trips()'
+      - name: Test validated landings
+        run: Rscript -e 'tinytest::run_test_file(system.file("tinytest/test_validated_pds_trips.R", package = "peskas.timor.data.pipeline"))'
 
   ingest-pds-tracks:
     name: Ingest pds tracks

--- a/.github/workflows/data-pipeline.yaml
+++ b/.github/workflows/data-pipeline.yaml
@@ -117,6 +117,8 @@ jobs:
         run: Rscript -e 'peskas.timor.data.pipeline::ingest_validation_tables()'
       - name: Validate landings
         run: Rscript -e 'peskas.timor.data.pipeline::validate_landings()'
+      - name: Test validated landings
+        run: Rscript -e 'tinytest::run_test_file("inst/tinytest/test_validated_landings.R")'
 
   ingest-pds-trips:
     name: Ingest pds trips

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,8 @@ Suggests:
     testthat,
     roxygen2,
     tidyselect,
-    textclean
+    textclean, 
+    tinytest
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: peskas.timor.data.pipeline
 Title: Functions to Implement the Timor Small Scale Fisheries
     Data Pipeline
-Version: 0.13.0
+Version: 0.14.0
 Authors@R: 
     c(person(given = "Fernando",
              family = "Cagua",

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN install2.r --error --skipinstalled \
     rlang \
     furrr \
     future \
-    univOutl
+    univOutl \
+    tinytest
 
 # Install suggests
 RUN install2.r --error --skipinstalled \

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -36,7 +36,8 @@ RUN install2.r --error --skipinstalled \
     rlang \
     furrr \
     future \
-    univOutl
+    univOutl \
+    tinytest
 
 # Install suggests
 RUN install2.r --error --skipinstalled \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# peskas.timor.data.pipeline 0.14.0
+
+## New features
+
+- We test validated data to ensure its integrity
+
 # peskas.timor.data.pipeline 0.13.0
 
 ## New features

--- a/R/get-cloud-files.R
+++ b/R/get-cloud-files.R
@@ -1,0 +1,22 @@
+
+get_validated_landings <- function(pars){
+  cloud_object_name(
+    prefix = paste0(pars$surveys$merged_landings$file_prefix, "_", "validated"),
+    provider = pars$storage$google$key,
+    options = pars$storage$google$options) %>%
+    download_cloud_file(
+      provider = pars$storage$google$key,
+      options = pars$storage$google$options) %>%
+    readr::read_rds()
+}
+
+get_validated_pds_trips <- function(pars){
+  cloud_object_name(
+    prefix = paste0(pars$pds$trips$file_prefix, "_", "validated"),
+    provider = pars$storage$google$key,
+    options = pars$storage$google$options) %>%
+    download_cloud_file(
+      provider = pars$storage$google$key,
+      options = pars$storage$google$options) %>%
+    readr::read_rds()
+}

--- a/R/validate-landings.R
+++ b/R/validate-landings.R
@@ -115,8 +115,8 @@ validate_landings <- function(log_threshold = logger::DEBUG){
       landing_date = .data$date,
       tracker_imei = .data$imei,
       trip_duration = .data$trip_duration,
-      landed_catch = .data$species_group,
-      landed_value = .data$total_catch_value)
+      landing_catch = .data$species_group,
+      landing_value = .data$total_catch_value)
 
   validated_landings_filename <- paste(pars$surveys$merged_landings$file_prefix,
                                        "validated", sep = "_") %>%

--- a/R/validate-pds-trips.R
+++ b/R/validate-pds-trips.R
@@ -43,7 +43,16 @@ validate_pds_trips <- function(log_threshold = logger::DEBUG){
          navigation_alerts$validated_pds_distance) %>%
     purrr::map(~ dplyr::select(.x,-alert_number)) %>%
     purrr::reduce(dplyr::left_join) %>%
-    dplyr::left_join(ready_cols)
+    dplyr::left_join(ready_cols) %>%
+    # rename columns that better align with the ontology terms
+    dplyr::rename(tracker_trip_duration = .data$`Duration (Seconds)`,
+                  tracker_trip_start = .data$Started,
+                  tracker_trip_end = .data$Ended,
+                  tracker_trip_id = .data$Trip,
+                  tracker_imei = .data$IMEI,
+                  tracker_device_id = .data$`Device Id`,
+                  tracker_last_seen = .data$`Last Seen`,
+                  tracker_trip_distance = .data$`Distance (Meters)`)
 
   validated_trips_filename <- paste(pars$pds$trips$file_prefix,
                                     "validated", sep = "_") %>%

--- a/inst/tinytest/test_validated_landings.R
+++ b/inst/tinytest/test_validated_landings.R
@@ -1,5 +1,7 @@
 
 logger::log_threshold(logger::ERROR)
+# Adjust the working directory so that when running localy the authentication
+# details in the config file load properly
 setwd("../..")
 pars <- peskas.timor.data.pipeline::read_config()
 

--- a/inst/tinytest/test_validated_landings.R
+++ b/inst/tinytest/test_validated_landings.R
@@ -1,3 +1,4 @@
+library(peskas.timor.data.pipeline)
 
 logger::log_threshold(logger::ERROR)
 # Adjust the working directory so that when running localy the authentication

--- a/inst/tinytest/test_validated_landings.R
+++ b/inst/tinytest/test_validated_landings.R
@@ -1,0 +1,67 @@
+
+logger::log_threshold(logger::ERROR)
+setwd("../..")
+pars <- peskas.timor.data.pipeline::read_config()
+
+validated_landings <- peskas.timor.data.pipeline:::get_validated_landings(pars)
+metadata <- peskas.timor.data.pipeline:::get_preprocessed_metadata(pars)
+
+# Function to check if there are negative values in a vector
+any_negative <- . %>% magrittr::is_less_than(0) %>% any() %>% isTRUE()
+
+catch <- validated_landings %>%
+  tidyr::unnest(landing_catch) %>%
+  tidyr::unnest(length_frequency)
+
+# Landing columns ---------------------------------------------------------
+
+expect_false(
+  any_negative(na.omit(validated_landings$trip_duration)),
+  "Negative trip durations in landings")
+
+expect_false(
+  any_negative(na.omit(validated_landings$landing_value)),
+  "Negative values in landings")
+
+expect_false(
+  any(na.omit(validated_landings$landing_date) > (Sys.Date() + 1)),
+  "Landing dates larger than current date + 1")
+
+expect_false(
+  any(na.omit(validated_landings$landing_date) <
+        lubridate::as_date("2017-01-01")),
+  "Landing dates prior to 2017")
+
+expect_true(
+  all(nchar(na.omit(validated_landings$tracker_imei)) == 15),
+  "IMEIs of not 15 characters"
+)
+
+# Catch columns -----------------------------------------------------------
+
+expect_false(
+  any_negative(na.omit(catch$length)),
+  "Negative catch lengths")
+
+expect_equal(
+  sort(unique(na.omit(catch$catch_purpose))),
+  c("both", "food", "sale"),
+  info = "Catch purpose has unepected values"
+)
+
+expect_true(
+  {
+    landing_codes <- na.omit(catch$catch_taxon)
+    valid_codes <- c(na.omit(metadata$catch_types$interagency_code), "0")
+    all(landing_codes %in% valid_codes)
+  },
+  "Catch codes has unepected values"
+)
+
+expect_false(
+  any_negative(na.omit(catch$individuals)),
+  "Negative catch numbers")
+
+expect_false(
+  anyNA(catch$catch_taxon),
+  "NA values in catch taxon")

--- a/inst/tinytest/test_validated_pds_trips.R
+++ b/inst/tinytest/test_validated_pds_trips.R
@@ -1,3 +1,5 @@
+library(peskas.timor.data.pipeline)
+
 logger::log_threshold(logger::ERROR)
 # Adjust the working directory so that when running localy the authentication
 # details in the config file load properly

--- a/inst/tinytest/test_validated_pds_trips.R
+++ b/inst/tinytest/test_validated_pds_trips.R
@@ -1,0 +1,65 @@
+logger::log_threshold(logger::ERROR)
+# Adjust the working directory so that when running localy the authentication
+# details in the config file load properly
+setwd("../..")
+pars <- peskas.timor.data.pipeline::read_config()
+
+pds_trips <- peskas.timor.data.pipeline:::get_validated_pds_trips(pars)
+
+trips <- pds_trips %>%
+  dplyr::mutate(
+    interval = lubridate::interval(
+      start = pds_trips$tracker_trip_start,
+      end = pds_trips$tracker_trip_end),
+    duration = lubridate::as.duration(interval))
+
+expect_true(
+  all(na.omit(pds_trips$tracker_trip_start) < Sys.time()),
+  "Trip starts are in the future")
+
+expect_true(
+  all(na.omit(pds_trips$tracker_trip_end) < Sys.time()),
+  "Trip ends are in the future")
+
+expect_true(
+  all(na.omit(pds_trips$tracker_trip_start) > lubridate::ymd("2017-01-01")),
+  "Trip starts are prior to 2017")
+
+expect_true(
+  all(na.omit(pds_trips$tracker_trip_end) > lubridate::ymd("2017-01-01")),
+  "Trip ends are prior to 2017")
+
+expect_true(
+  all(na.omit(pds_trips$tracker_trip_start < pds_trips$tracker_trip_end)),
+  "Trip start time is after trip end"
+)
+
+expect_true(
+  all(na.omit(as.numeric(trips$duration) == trips$tracker_trip_duration)),
+  "Indicated and calculated trip duration differ"
+)
+
+# Skipping overlap test for now as it takes way too long
+# do_intervals_overlap <- function(x){
+#   if (length(x) <= 1) return(FALSE)
+#   x %>% combn(2, simplify = F) %>%
+#     purrr::map_lgl(~ lubridate::int_overlaps(.[1], .[2])) %>%
+#     any()
+# }
+#
+# interval_overlaps <- trips %>%
+#   dplyr::filter(!is.na(tracker_trip_start)) %>%
+#   dplyr::mutate(week = lubridate::floor_date(tracker_trip_start, "day")) %>%
+#   dplyr::group_by(tracker_imei, week) %>%
+#   dplyr::summarise(overlap = do_intervals_overlap(interval))
+#
+# expect_false(
+#   any(interval_overlaps$overlap),
+#   "Trips from a same IMEI overlap in time"
+# )
+
+expect_true(
+  all(na.omit(trips$tracker_last_seen > trips$tracker_trip_start)) &
+    all(na.omit(trips$tracker_last_seen > trips$tracker_trip_end)),
+  "The last seen date-time is earlier than the trip start or end time"
+)


### PR DESCRIPTION
This feature attempts to add data testing to the pipeline. This is important because as there are more and more moving pieces in the pipeline the ability to keep an oversight over the changes decreases. Tests will help make sure that errors are not propagated throughout the pipeline. 

The initial focus is on the validated landings and the validated PDS trips. For now I've included them as a step in the respective jobs but there might be a more effective approach. 

I've used the package tinytest which seems simple enough and allow us to save the tests as data in case we need that information later.