### PR TITLE
Feat/catch composition

### DIFF
--- a/R/format-public-data.R
+++ b/R/format-public-data.R
@@ -71,10 +71,10 @@ format_public_data <- function(log_threshold = logger::DEBUG){
                 options = pars$public_storage$google$options)
 
   logger::log_info("Saving and exporting public data as rds")
-  c('trips', "catch", "aggregated") %>%
+  c('trips', "catch", "aggregated", "taxa_aggregated") %>%
     paste0(pars$export$file_prefix, "_", .) %>%
     purrr::map_chr(add_version, extension = "rds") %T>%
-    purrr::walk2(list(trips_table, catch_table, aggregated),
+    purrr::walk2(list(trips_table, catch_table, aggregated, taxa_estimations),
                  ~ readr::write_rds(.y, .x, compress = "gz")) %>%
     purrr::walk(upload_cloud_file,
                 provider = pars$public_storage$google$key,

--- a/R/format-public-data.R
+++ b/R/format-public-data.R
@@ -197,7 +197,7 @@ summarise_estimations <- function(bin_unit = "month", aggregated_predictions, gr
     dplyr::mutate(
       current_period =
         today >= .data$date_bin_start &
-        today < dplyr::lead(date_bin_start),
+        today < dplyr::lead(.data$date_bin_start),
       elapsed = as.numeric(today - .data$date_bin_start + 1),
       period_length = as.numeric(dplyr::lead(.data$date_bin_start) - .data$date_bin_start),
       n_landings_per_boat = dplyr::if_else(current_period, .data$n_landings_per_boat * .data$elapsed / .data$period_length, .data$n_landings_per_boat),
@@ -230,4 +230,17 @@ summarise_estimations <- function(bin_unit = "month", aggregated_predictions, gr
 
   binned_frame
 
+}
+
+
+where <- function (fn)
+{
+  predicate <- rlang::as_function(fn)
+  function(x, ...) {
+    out <- predicate(x, ...)
+    if (!rlang::is_bool(out)) {
+      rlang::abort("`where()` must be used with functions that return `TRUE` or `FALSE`.")
+    }
+    out
+  }
 }

--- a/R/model_catch.R
+++ b/R/model_catch.R
@@ -216,6 +216,8 @@ model_catch <- function(trips){
                                                          unit = "month")) %>%
     tidyr::unnest(.data$landing_catch) %>%
     tidyr::unnest(.data$length_frequency) %>%
+    dplyr::group_by(.data$landing_id) %>%
+    dplyr::filter(all(!is.na(.data$landing_period)), all(!is.na(.data$weight)), all(!is.na(.data$catch_taxon)), all(!is.na(reporting_region))) %>%
     dplyr::filter(!is.na(.data$landing_period), !is.na(.data$landing_value)) %>%
     dplyr::mutate(landing_id = as.character(.data$landing_id),
                   weight = dplyr::if_else(.data$weight < 0, NA_real_, .data$weight)) %>%

--- a/R/preprocess-metadata-tables.R
+++ b/R/preprocess-metadata-tables.R
@@ -64,7 +64,9 @@ preprocess_metadata_tables <- function(log_threshold = logger::DEBUG){
     morphometric_table = pt_validate_morphometric_table(metadata_tables$morphometric_table),
     centro_pescas = pt_validate_centro_pescas(metadata_tables$centro_pescas),
     vessel_types = pt_validate_vessel_types(metadata_tables$vessel_types),
-    gear_types = pt_validate_gear_types(metadata_tables$gear_types))
+    gear_types = pt_validate_gear_types(metadata_tables$gear_types),
+    stations = pt_validate_stations(metadata_tables$stations),
+    reporting_unit = pt_validate_reporting_unit(metadata_tables$reporting_unit))
 
   preprocessed_filename <- paste(pars$metadata$airtable$name,
                                  "preprocessed", sep = "_") %>%
@@ -244,4 +246,12 @@ pt_validate_gear_types <- function(gear_types_table){
 
 pt_validate_vessel_types <- function(vessel_types_table){
   vessel_types_table
+}
+
+pt_validate_stations <- function(stations_table){
+  stations_table
+}
+
+pt_validate_reporting_unit <- function(x){
+  x
 }

--- a/R/validate-landings.R
+++ b/R/validate-landings.R
@@ -70,6 +70,10 @@ validate_landings <- function(log_threshold = logger::DEBUG){
   gear_type_alerts <- validate_gear_type(
     landings,
     metadata$gear_types)
+  site_alerts <- validate_sites(
+    landings,
+    metadata$stations, metadata$reporting_unit
+  )
 
 
   # CREATE VALIDATED OUTPUT -----------------------------------------------
@@ -102,7 +106,8 @@ validate_landings <- function(log_threshold = logger::DEBUG){
          surveys_price_alerts,
          surveys_catch_alerts,
          vessel_type_alerts,
-         gear_type_alerts) %>%
+         gear_type_alerts,
+         site_alerts) %>%
     purrr::map(~ dplyr::select(.x,-alert_number)) %>%
     purrr::reduce(dplyr::left_join, by = "submission_id") %>%
     dplyr::left_join(ready_cols, by = "submission_id") %>%
@@ -129,6 +134,8 @@ validate_landings <- function(log_threshold = logger::DEBUG){
       trip_duration = .data$trip_duration,
       landing_catch = .data$species_group,
       landing_value = .data$total_catch_value,
+      landing_station = .data$station_name,
+      reporting_region = .data$reporting_region,
       #municipality = .data$`municipality (from administrative_posts)`,
       .data$gear_type,
       .data$vessel_type)

--- a/R/validation-functions.R
+++ b/R/validation-functions.R
@@ -286,7 +286,7 @@ validate_vessel_type <- function(data, metadata_vessel_table){
   data %>%
     dplyr::rename(submission_id = .data$`_id`,
                   boat_code = .data$`trip_group/boat_type`) %>%
-    dplyr::mutate(boat_code = as.integer(boat_code)) %>%
+    dplyr::mutate(boat_code = as.integer(.data$boat_code)) %>%
     dplyr::left_join(metadata_vessel_table, by = "boat_code") %>%
     dplyr::rename(vessel_type = .data$boat_type) %>%
     # If no vessel type is not what we expected
@@ -336,7 +336,7 @@ validate_sites <- function(data, metadata_stations, metadata_reporting_units){
     dplyr::select(.data$submission_id, .data$station_code) %>%
     dplyr::left_join(sites_df, by = "station_code") %>%
     # If the station is not known to us
-    dplyr::mutate(alert_number = dplyr::if_else(is.na(station_name) | is.na(reporting_region), 16, NA_real_)) %>%
+    dplyr::mutate(alert_number = dplyr::if_else(is.na(.data$station_name) | is.na(.data$reporting_region), 16, NA_real_)) %>%
     # Fixing types
     dplyr::mutate(submission_id = as.integer(.data$submission_id))
 }

--- a/R/validation-functions.R
+++ b/R/validation-functions.R
@@ -318,3 +318,25 @@ validate_gear_type <- function(data, metadata_gear_table){
 
 
 }
+
+validate_sites <- function(data, metadata_stations, metadata_reporting_units){
+
+  sites_df <-
+    metadata_stations %>%
+    dplyr::filter(!is.na(.data$station_code)) %>%
+    dplyr::inner_join(metadata_reporting_units, by = c("reporting_unit" = "id")) %>%
+    dplyr::select(.data$station_code, .data$station_name, .data$reporting_unit.y) %>%
+    dplyr::mutate(station_code = as.character(.data$station_code)) %>%
+    dplyr::mutate(station_name = trimws(.data$station_name)) %>%
+    dplyr::rename(reporting_region = .data$reporting_unit.y)
+
+  data %>%
+    dplyr::rename(submission_id = .data$`_id`) %>%
+    dplyr::mutate(station_code = as.character(.data$landing_site_name)) %>%
+    dplyr::select(.data$submission_id, .data$station_code) %>%
+    dplyr::left_join(sites_df, by = "station_code") %>%
+    # If the station is not known to us
+    dplyr::mutate(alert_number = dplyr::if_else(is.na(station_name) | is.na(reporting_region), 16, NA_real_)) %>%
+    # Fixing types
+    dplyr::mutate(submission_id = as.integer(.data$submission_id))
+}

--- a/inst/conf.yml
+++ b/inst/conf.yml
@@ -96,6 +96,7 @@ default:
 
   models:
     file_prefix: model_predictions
+    modelled_taxa: [CLP, OCZ, CJX, SDX, BEN, EMP, FLY, SNA, RAX, CGX, TUN]
 
   export:
     file_prefix: timor

--- a/inst/conf.yml
+++ b/inst/conf.yml
@@ -53,6 +53,8 @@ default:
         - centro_pescas
         - vessel_types
         - gear_types
+        - stations
+        - reporting_units
     version:
       preprocess: latest
     rfishtable:


### PR DESCRIPTION
The purpose of this merge is to add support for the 

**New features**

- Validated data now includes sites and municipalities
- A new model that estimates catch per trip at the taxa level. Only the top 11 taxa are modelled. All other are grouped into MZZ code. 
- Models of national catch now are based only on observations where municipality and taxon data is present. This is so that it agrees with the estimations produced by the model that estimate catch at the taxa level. However, there are still differences between the estimations. 
- Export data

**Issues fixed**

- Estimates for the current month were calculated as for the whole month even if only a few days had passed. This is now adjusted. 

**Known problems**

- Octopus estimation might be problematic. If the weight estimation cannot be easily resolved these need to be removed from the overall catch. 
- Estimates from the models at the taxa level are not exactly the same as that for the whole country. 
- Exported, aggregated data in `.tsv` format does not include the new estimates per taxa. Currently they are only exported in the aggregated `.rds` format which is used by the portal. 