### PR TITLE
Fix pds step

### DIFF
--- a/.github/workflows/data-pipeline.yaml
+++ b/.github/workflows/data-pipeline.yaml
@@ -125,8 +125,8 @@ jobs:
       - name: Test validated landings
         run: Rscript -e 'tinytest::run_test_file(system.file("tinytest/test_validated_landings.R", package = "peskas.timor.data.pipeline"))'
 
-  ingest-pds-data:
-    name: Ingest pds trips and tracks
+  ingest-pds-trips:
+    name: Ingest pds trips
     needs: build-container
     runs-on: ubuntu-20.04
     container:
@@ -140,12 +140,26 @@ jobs:
         run: echo "R_CONFIG_ACTIVE=production" >> $GITHUB_ENV
       - name: Call ingest_pds_trips()
         run: Rscript -e 'peskas.timor.data.pipeline::ingest_pds_trips()'
+
+  ingest-pds-tracks:
+    name: Ingest pds tracks
+    needs: build-container
+    runs-on: ubuntu-20.04
+    container:
+      image: docker.pkg.github.com/worldfishcenter/peskas.timor.data.pipeline/r-runner-peskas-timor
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Set env to production
+        if: endsWith(github.ref, '/main')
+        run: echo "R_CONFIG_ACTIVE=production" >> $GITHUB_ENV
       - name: Call ingest_pds_tracks()
         run: Rscript -e 'peskas.timor.data.pipeline::ingest_pds_tracks()'
 
-  preprocess-validate-pds:
-    name: Preprocess & validate pds
-    needs: ingest-pds-data
+  preprocess-pds-data:
+    name: Preprocess pds data
+    needs: [ingest-pds-trips, ingest-pds-tracks]
     runs-on: ubuntu-20.04
     container:
       image: docker.pkg.github.com/worldfishcenter/peskas.timor.data.pipeline/r-runner-peskas-timor
@@ -160,6 +174,20 @@ jobs:
         run: Rscript -e 'peskas.timor.data.pipeline::preprocess_pds_trips()'
       - name: Call preprocess_pds_tracks()
         run: Rscript -e 'peskas.timor.data.pipeline::preprocess_pds_tracks()'
+
+  validate-pds-data:
+    name: Validate pds data
+    needs: preprocess-pds-data
+    runs-on: ubuntu-20.04
+    container:
+      image: docker.pkg.github.com/worldfishcenter/peskas.timor.data.pipeline/r-runner-peskas-timor
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Set env to production
+        if: endsWith(github.ref, '/main')
+        run: echo "R_CONFIG_ACTIVE=production" >> $GITHUB_ENV
       - name: Call validate_pds_trips()
         run: Rscript -e 'peskas.timor.data.pipeline::validate_pds_trips()'
       - name: Test validated PDS trips
@@ -167,7 +195,7 @@ jobs:
 
   merge-trips:
     name: Merge trips
-    needs: [validate-landings, preprocess-validate-pds]
+    needs: [validate-landings, validate-pds-data]
     runs-on: ubuntu-20.04
     container:
       image: docker.pkg.github.com/worldfishcenter/peskas.timor.data.pipeline/r-runner-peskas-timor

--- a/.github/workflows/data-pipeline.yaml
+++ b/.github/workflows/data-pipeline.yaml
@@ -125,7 +125,7 @@ jobs:
       - name: Test validated landings
         run: Rscript -e 'tinytest::run_test_file(system.file("tinytest/test_validated_landings.R", package = "peskas.timor.data.pipeline"))'
 
-  ingest-pds-trips:
+  ingest-pds-data:
     name: Ingest pds trips and tracks
     needs: build-container
     runs-on: ubuntu-20.04
@@ -143,9 +143,9 @@ jobs:
       - name: Call ingest_pds_tracks()
         run: Rscript -e 'peskas.timor.data.pipeline::ingest_pds_tracks()'
 
-  preprocess-pds-tracks:
-    name: Preprocess pds trips and tracks
-    needs: ingest-pds-trips
+  preprocess-validate-pds:
+    name: Preprocess & validate pds
+    needs: ingest-pds-data
     runs-on: ubuntu-20.04
     container:
       image: docker.pkg.github.com/worldfishcenter/peskas.timor.data.pipeline/r-runner-peskas-timor
@@ -167,7 +167,7 @@ jobs:
 
   merge-trips:
     name: Merge trips
-    needs: [validate-landings, ingest-pds-trips]
+    needs: [validate-landings, preprocess-validate-pds]
     runs-on: ubuntu-20.04
     container:
       image: docker.pkg.github.com/worldfishcenter/peskas.timor.data.pipeline/r-runner-peskas-timor


### PR DESCRIPTION
Hey @efcaguab , there is some mess in the main branch following the merge with pds update.

1. I forgot to update the YAML pipeline (fixed in the latest commit of this branch).

2. The `preprocess_pds_tracks` function goes beyond 6 hours and the pipeline stops. This is because `preprocess_pds_tracks` searches the bucket for the file with preprocessed tracks (those prefixed with **pds-track_preprocessed**), reads it, and join it with the missing preprocessed tracks (the new ones). If the preprocessed tracks file is not in the bucket, `preprocess_pds_tracks` creates a new **pds-track_preprocessed** and starts downloading and preprocessing all the pds tracks from the beginning to compile the newly created file. Since this latter operation takes a long time, I populated the first **pds-track_preprocessed** file in several bunches. So, now that the bucket moved to the production one, **pds-track_preprocessed** file is missing and its creation and compilation exceeds the 6 hours.

Possible solutions:
1) Speed up the process of creating and compiling **pds-track_preprocessed**.
2) Copy the most recent **pds-track_preprocessed** file from the development bucket into the production bucket.

If I'm not missing any relevant problem, I would choose solution 2.