### PR TITLE
Validate number of fishers

### DIFF
--- a/R/format-public-data.R
+++ b/R/format-public-data.R
@@ -110,7 +110,8 @@ add_calculated_fields <- function(merged_trips){
     dplyr::ungroup() %>%
     dplyr::mutate(n_taxa = purrr::map_int(.data$landing_catch, count_taxa)) %>%
     dplyr::mutate(taxa = purrr::map_chr(.data$landing_catch, collapse_taxa)) %>%
-    dplyr::mutate(landing_date = lubridate::as_date(.data$landing_date))
+    dplyr::mutate(landing_date = lubridate::as_date(.data$landing_date))# %>%
+    # dplyr::mutate(fisher_proportion_woman = fisher_number_woman / (fisher_number_child + fisher_number_man + fisher_number_woman))
 }
 
 #'@importFrom rlang .data
@@ -123,6 +124,11 @@ get_trips_table <- function(merged_trips_with_addons){
       landing_n_taxa = .data$n_taxa,
       landing_taxa = .data$taxa,
       .data$landing_value,
+      .data$landing_catch,
+      .data$vessel_type,
+      .data$landing_station,
+      .data$reporting_region,
+      tidyselect::starts_with("fisher_"),
       landing_survey_trip_duration = .data$trip_duration,
       .data$tracker_trip_start,
       .data$tracker_trip_end,
@@ -147,7 +153,8 @@ summarise_trips <- function(bin_unit = "month", merged_trips_with_addons){
                                                          bin_unit,
                                                          week_start = 7)) %>%
     dplyr::group_by(.data$date_bin_start) %>%
-    dplyr::summarise(n_landings = dplyr::n_distinct(.data$landing_id, na.rm = T))
+    dplyr::summarise(n_landings = dplyr::n_distinct(.data$landing_id, na.rm = T),
+                     prop_landings_woman = sum(fisher_number_woman > 0, na.rm = T) / sum(!is.na(fisher_number_woman), na.rm = T))
 
    track_end_bin <- merged_trips_with_addons %>%
      dplyr::mutate(tracker_trip_end = lubridate::as_date(.data$tracker_trip_end),

--- a/R/validate-landings.R
+++ b/R/validate-landings.R
@@ -79,6 +79,11 @@ validate_landings <- function(log_threshold = logger::DEBUG){
     landings,
     metadata$stations, metadata$reporting_unit
   )
+  n_fishers_alerts <- validate_n_fishers(
+    landings,
+    method = pars$validation$landings$n_fishers$method %||% default_method,
+    k = pars$validation$landings$n_fishers$k %||% default_k
+  )
 
 
   # CREATE VALIDATED OUTPUT -----------------------------------------------
@@ -99,7 +104,8 @@ validate_landings <- function(log_threshold = logger::DEBUG){
          price_weight_alerts,
          vessel_type_alerts,
          gear_type_alerts,
-         site_alerts) %>%
+         site_alerts,
+         n_fishers_alerts) %>%
     purrr::map(~ dplyr::select(.x,-alert_number)) %>%
     purrr::reduce(dplyr::left_join, by = "submission_id") %>%
     dplyr::left_join(ready_cols, by = "submission_id") %>%
@@ -126,6 +132,7 @@ validate_landings <- function(log_threshold = logger::DEBUG){
       landing_value = .data$total_catch_value,
       landing_station = .data$station_name,
       reporting_region = .data$reporting_region,
+      tidyselect::starts_with("fisher_number"),
       ##municipality = .data$`municipality (from administrative_posts)`,
       .data$gear_type,
       .data$vessel_type)

--- a/R/validation-functions.R
+++ b/R/validation-functions.R
@@ -420,3 +420,19 @@ validate_sites <- function(data, metadata_stations, metadata_reporting_units){
     # Fixing types
     dplyr::mutate(submission_id = as.integer(.data$submission_id))
 }
+
+
+validate_n_fishers <- function(landings, method, k){
+
+  landings %>%
+    dplyr::select(submission_id = .data$`_id`,
+                  fisher_number_child = .data$`trip_group/no_fishers/no_child_fishers`,
+                  fisher_number_man = .data$`trip_group/no_fishers/no_men_fishers`,
+                  fisher_number_woman = .data$`trip_group/no_fishers/no_women_fishers`) %>%
+    dplyr::mutate(dplyr::across(tidyselect::starts_with("fisher"), as.numeric)) %>%
+    dplyr::mutate(dplyr::across(tidyselect::starts_with("fisher"), list(alert = alert_outlier), alert_if_larger = 18, alert_if_smaller = 18, k = k, logt = T, method = method)) %>%
+    dplyr::mutate(alert_number = dplyr::coalesce(fisher_number_child, fisher_number_man, fisher_number_woman)) %>%
+    dplyr::mutate(dplyr::across(tidyselect::starts_with("fisher"), ~dplyr::if_else(is.na(alert_number), NA_real_, .))) %>%
+    dplyr::select(-tidyselect::ends_with("alert"))
+
+}

--- a/R/validation-functions.R
+++ b/R/validation-functions.R
@@ -433,6 +433,8 @@ validate_n_fishers <- function(landings, method, k){
     dplyr::mutate(dplyr::across(tidyselect::starts_with("fisher"), list(alert = alert_outlier), alert_if_larger = 18, alert_if_smaller = 18, k = k, logt = T, method = method)) %>%
     dplyr::mutate(alert_number = dplyr::coalesce(fisher_number_child, fisher_number_man, fisher_number_woman)) %>%
     dplyr::mutate(dplyr::across(tidyselect::starts_with("fisher"), ~dplyr::if_else(is.na(alert_number), NA_real_, .))) %>%
-    dplyr::select(-tidyselect::ends_with("alert"))
+    dplyr::select(-tidyselect::ends_with("alert")) %>%
+    # Fixing types
+    dplyr::mutate(submission_id = as.integer(.data$submission_id))
 
 }


### PR DESCRIPTION
The purpose of this pull request is to add the number of fishers into the pipeline so it can be used in the portal. 

**New features**

- New alert for outlier in number of fishers in airtable (alert number 18)
- New columns in the public trips data frame, namely `fisher_n_man`, `fisher_n_woman`, and `fisher_n_child`
- New columns in the public aggregated data frame, namely  `prop_landings_woman` with the proportion of landings where a woman was recorded

**Issues fixed**

- Added other columns that have been validated but were not included in the clean trips_table data frame that's exported
