### PR TITLE
Swapping octopus for MOO and reordering given newer calculations

### DIFF
--- a/inst/conf.yml
+++ b/inst/conf.yml
@@ -105,7 +105,7 @@ default:
 
   models:
     file_prefix: model_predictions
-    modelled_taxa: [CLP, OCZ, CJX, SDX, BEN, EMP, FLY, SNA, RAX, CGX, TUN]
+    modelled_taxa: [CLP, CJX, SDX, BEN, TUN, EMP, FLY, SNA, RAX, CGX, MOO]
 
   export:
     file_prefix: timor


### PR DESCRIPTION
This feature replaces octopuses (OCZ) for Moonfish (MOO). After correcting for the length measurement used OCZ is not one of the top taxa caught.

Also, for some reason TUN catches have increased a lot. I suspect because we were filtering out a few of those before @langbart  updated the outlier detection. Looks much better now. 