### PR TITLE
Update boats number - improve estimates model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,8 @@ Suggests:
     leaflet,
     htmltools,
     imputeTS,
-    Amelia
+    Amelia,
+    mice
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,7 @@ Imports:
     purrr,
     readr,
     tidyr,
-    rlang (>= 0.1.2),
-    imputeTS
+    rlang (>= 0.1.2)
 Suggests: 
     covr,
     pkgdown,
@@ -67,7 +66,9 @@ Suggests:
     univOutl,
     zip,
     leaflet,
-    htmltools
+    htmltools,
+    imputeTS,
+    Amelia
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: peskas.timor.data.pipeline
 Title: Functions to Implement the Timor Small Scale Fisheries
     Data Pipeline
-Version: 1.3.0
+Version: 1.4.0
 Authors@R: 
     c(person(given = "Fernando",
              family = "Cagua",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:4.1.1
+FROM rocker/geospatial:4.2
 
 # Install imports
 RUN install2.r --error --skipinstalled \
@@ -56,6 +56,7 @@ RUN install2.r --error --skipinstalled \
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz
-RUN Rscript -e "devtools::install_version('glmmTMB', version = '1.1.5')"
+RUN installGithub.r glmmTMB/glmmTMB/glmmTMB
+#RUN Rscript -e "devtools::install_version('glmmTMB', version = '1.1.5')"
 # Rstudio interface preferences
 COPY rstudio-prefs.json /home/rstudio/.config/rstudio/rstudio-prefs.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN install2.r --error --skipinstalled \
     zip \
     leaflet \
     htmltools \
-    Amelia
+    Amelia \
+    mice
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN install2.r --error --skipinstalled \
     config \
     dplyr \
     git2r \
-    glmmTMB \
     googleAuthR \
     googleCloudStorageR \
     googledrive \
@@ -57,5 +56,6 @@ RUN install2.r --error --skipinstalled \
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz
+RUN "install_version('glmmTMB', version = '1.1.5', dependencies= T)"
 # Rstudio interface preferences
 COPY rstudio-prefs.json /home/rstudio/.config/rstudio/rstudio-prefs.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN install2.r --error --skipinstalled \
     tidytext \
     zip \
     leaflet \
-    htmltools
+    htmltools \
+    Amelia
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,6 @@ RUN install2.r --error --skipinstalled \
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz
-RUN "install_version('glmmTMB', version = '1.1.5', dependencies= T)"
+RUN Rscript -e "install_version('glmmTMB', version = '1.1.5')"
 # Rstudio interface preferences
 COPY rstudio-prefs.json /home/rstudio/.config/rstudio/rstudio-prefs.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,6 @@ RUN install2.r --error --skipinstalled \
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz
-RUN Rscript -e "install_version('glmmTMB', version = '1.1.5')"
+RUN Rscript -e "devtools::install_version('glmmTMB', version = '1.1.5')"
 # Rstudio interface preferences
 COPY rstudio-prefs.json /home/rstudio/.config/rstudio/rstudio-prefs.json

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:4.1.1
+FROM rocker/geospatial:4.2
 
 # Tidyverse system requirements
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
@@ -69,7 +69,7 @@ RUN install2.r --error --skipinstalled \
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz
-RUN Rscript -e "devtools::install_version('glmmTMB', version = '1.1.5')"
+RUN installGithub.r glmmTMB/glmmTMB/glmmTMB
 # Install local package
 COPY . /home
 WORKDIR /home

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -18,7 +18,6 @@ RUN install2.r --error --skipinstalled \
     config \
     dplyr \
     git2r \
-    glmmTMB \
     googleAuthR \
     googleCloudStorageR \
     googledrive \
@@ -70,6 +69,7 @@ RUN install2.r --error --skipinstalled \
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz
+RUN "install_version('glmmTMB', version = '1.1.5', dependencies= T)"
 # Install local package
 COPY . /home
 WORKDIR /home

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -65,7 +65,8 @@ RUN install2.r --error --skipinstalled \
     zip \
     leaflet \
     htmltools \
-    Amelia
+    Amelia \
+    mice
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -69,7 +69,7 @@ RUN install2.r --error --skipinstalled \
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz
-RUN "install_version('glmmTMB', version = '1.1.5', dependencies= T)"
+RUN Rscript -e "install_version('glmmTMB', version = '1.1.5')"
 # Install local package
 COPY . /home
 WORKDIR /home

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -65,7 +65,8 @@ RUN install2.r --error --skipinstalled \
     tidytext \
     zip \
     leaflet \
-    htmltools
+    htmltools \
+    Amelia
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -69,7 +69,7 @@ RUN install2.r --error --skipinstalled \
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz
-RUN Rscript -e "install_version('glmmTMB', version = '1.1.5')"
+RUN Rscript -e "devtools::install_version('glmmTMB', version = '1.1.5')"
 # Install local package
 COPY . /home
 WORKDIR /home

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# peskas.timor.data.pipeline 1.4.0
+
+## Improvements
+
+- Improve national and municipal estimates combining packags `Amelia` and
+`mice` for missing and outliers data imputation.
+
+- Integrating price per kg into export data
+
+## Bug fixes
+
+- Improved revenue outliers identification based on empirical information
+
+
 # peskas.timor.data.pipeline 1.3.0
 
 ## New features

--- a/R/calculate-nutrients.R
+++ b/R/calculate-nutrients.R
@@ -29,7 +29,7 @@ get_nutrients_table <- function(pars, summarise = TRUE, convert = TRUE) {
       show_col_types = FALSE
     ) %>%
     dplyr::rename(SpecCode = .data$spec_code) %>%
-    dplyr::mutate(SpecCode = as.character(.data$SpecCode)) %>%
+    dplyr::mutate(SpecCode = as.integer(.data$SpecCode)) %>%
     dplyr::select(.data$species, .data$SpecCode, tidyselect::contains("_mu")) %>%
     dplyr::right_join(rfish_tab, by = "SpecCode") %>%
     dplyr::select(.data$interagency_code, tidyselect::contains("_mu"))

--- a/R/format-public-data.R
+++ b/R/format-public-data.R
@@ -302,6 +302,7 @@ summarise_estimations <- function(bin_unit = "month", aggregated_predictions, gr
   today <- Sys.Date()
 
   if (length(groupings) > 1) {
+
     standardised_predictions <- aggregated_predictions %>%
       dplyr::rename(date_bin_start = .data$landing_period) %>%
       tidyr::complete(date_bin_start = all_months) %>%
@@ -330,7 +331,7 @@ summarise_estimations <- function(bin_unit = "month", aggregated_predictions, gr
       dplyr::summarise(
         landing_revenue = mean(.data$landing_revenue, na.rm = T),
         landing_weight = mean(.data$landing_weight, na.rm = T),
-        n_landings_per_boat = sum(.data$n_landings_per_boat), na.rm = T,
+        n_landings_per_boat = sum(.data$n_landings_per_boat, na.rm = T),
         revenue = sum(.data$revenue, na.rm = T),
         catch = sum(.data$catch, na.rm = T)
       ) %>%

--- a/R/preprocess-metadata-tables.R
+++ b/R/preprocess-metadata-tables.R
@@ -70,7 +70,8 @@ preprocess_metadata_tables <- function(log_threshold = logger::DEBUG) {
     stations = pt_validate_stations(metadata_tables$stations),
     reporting_unit = pt_validate_reporting_unit(metadata_tables$reporting_unit),
     habitat = pt_validate_habitat(metadata_tables$habitat),
-    vessels_stats = pt_validate_vessels_stats(metadata_tables$fishing_vessel_statistics)
+    vessels_stats = pt_validate_vessels_stats(metadata_tables$fishing_vessel_statistics),
+    registered_boats = pt_validate_reg_boats(metadata_tables$registered_boats)
   )
 
   preprocessed_filename <- paste(pars$metadata$airtable$name,
@@ -284,4 +285,17 @@ pt_validate_vessels_stats <- function(vessels_stats_table) {
     ) %>%
     dplyr::select(.data$reporting_region, .data$type, .data$n_boats, .data$info_date) %>%
     dplyr::mutate(dplyr::across(where(is.character), stringr::str_trim))
+}
+
+pt_validate_reg_boats <- function(reg_boats_table) {
+  reg_boats_table %>%
+    dplyr::select(
+      reporting_region = .data$Municipality,
+      boats_2016 = .data$registered_boats_2016,
+      boats_2022 = .data$registered_boats_2022
+    ) %>%
+    dplyr::rowwise() %>%
+    dplyr::mutate(n_boats = sum(.data$boats_2016, .data$boats_2022, na.rm = T)) %>%
+    dplyr::select(-c(.data$boats_2016, .data$boats_2022)) %>%
+    dplyr::ungroup()
 }

--- a/R/validation-functions.R
+++ b/R/validation-functions.R
@@ -211,10 +211,11 @@ validate_catch_price <- function(data, method = NULL, k = NULL) {
     dplyr::filter(is.na(.data$alert_number)) %>%
     dplyr::select(.data$`_id`, .data$total_catch_value) %>%
     dplyr::transmute(
-      alert_number = alert_outlier(
-        x = .data$total_catch_value, alert_if_smaller = 9, alert_if_larger = 6,
-        logt = TRUE, k = k, method = method
-      ),
+      alert_number = ifelse(.data$total_catch_value > 1500, 6, NA_integer_),
+      #alert_number = alert_outlier(
+      #  x = .data$total_catch_value, alert_if_smaller = 9, alert_if_larger = 6,
+      #  logt = TRUE, k = k, method = method
+      #),
       total_catch_value = dplyr::case_when(
         is.na(.data$alert_number) ~ .data$total_catch_value,
         TRUE ~ NA_real_

--- a/inst/conf.yml
+++ b/inst/conf.yml
@@ -140,7 +140,7 @@ default:
   models:
     file_prefix: model_predictions
     all_taxa: [APO, BAR, BEN, BGX, BWH, CBA, CGX, CJX, CLP, COZ, CRA, CUX, DOS, DOX, DRZ, DSF, ECN, EMP, FLY, GOX, GPX, GRX, GZP, IAX,IHX, KYX, LGE, LWX, MHL, MIL, MOB, MOJ, MOO, MUI, MUL, OCZ, PEZ, PUX, PWT, RAX, SDX, SFA, SKH, SLV, SNA, SPI, SRX, SUR, SWX, THF, THO, TRI, TUN, WRA, YDX, MZZ]
-    modelled_taxa: [CLP, CJX, SDX, BEN, TUN, EMP, FLY, SNA, RAX, CGX, GZP, MZZ]
+    modelled_taxa: [CJX, CLP, SDX, BEN, FLY, EMP, RAX, CGX, SNA, TUN, PWT, MZZ]
 
   export:
     file_prefix: timor

--- a/inst/conf.yml
+++ b/inst/conf.yml
@@ -71,6 +71,7 @@ default:
         - reporting_units
         - habitat
         - fishing_vessel_statistics
+        - registered_boats
     version:
       preprocess: latest
     rfishtable:

--- a/inst/report/data_report.Rmd
+++ b/inst/report/data_report.Rmd
@@ -92,7 +92,8 @@ catch <-
   dplyr::ungroup()
 
 # palettes
-year_palette <- rev(c("#bda639", "#1b5767", "#629a9b", "#c51f5d", "#92684d"))
+year_palette <- 
+  rev(c("#bda639", "#1b5767", "#629a9b", "#c51f5d", "#92684d", "#9ECE9A"))
 catch_use_palette <- rev(c("#9f8985", "#87bdbc", "#dbdbc9"))
 
 # help functions


### PR DESCRIPTION
This pull integrates the number of registered boats updated to 2022 and improves models estimates:

- improve model performance using Gamma distribution for n° landings
- manage estimates outliers using imputed data with multivariate imputation (`mice` and `Amelia` packages)

It adds price per Kg into export data