### PR TITLE
Fix price weight estimation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,7 @@ Imports:
     purrr,
     readr,
     tidyr,
-    rlang (>= 0.1.2),
-    keyring
+    rlang (>= 0.1.2)
 Suggests: 
     covr,
     pkgdown,

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ RUN install2.r --error --skipinstalled \
     mice \
     blastula \
     glue \
-    mime \
-    keyring
+    mime
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -69,8 +69,7 @@ RUN install2.r --error --skipinstalled \
     mice \
     blastula \
     glue \
-    mime \
-    keyring
+    mime
 
 # Install GitHub packages
 RUN installGithub.r wilkelab/ungeviz


### PR DESCRIPTION
Price per weight was calculated using revenue and weight from all trips, however many trips have no weight as we have no weight information for many fish groups (miscellaneous fish, cuttlefish...). This caused price per weight higher than expected. This pull fix this situation by estimating price per weight only on trips for which weight was available